### PR TITLE
datepicker fix

### DIFF
--- a/src/app/mini-components/transformations/calendar/calendar.component.html
+++ b/src/app/mini-components/transformations/calendar/calendar.component.html
@@ -1,15 +1,15 @@
 <div class="dlt-form-item input"
-    *ngIf="transform && sendableField" 
-    [ngStyle]="{'grid-row-start': field.position.row, 'grid-column-start': field.position.column, 
-                'grid-column-end': field.position.column + transform.dateInputFields[0].format.length + 2}">
+  *ngIf="transform && sendableField" 
+  [ngStyle]="{'grid-row-start': field.position.row, 'grid-column-start': field.position.column, 
+    'grid-column-end': field.position.column + transform.dateInputFields[0].format.length + 2}">
   <div class="dlt-form-group">
-    <input [attr.data-toggle]="this.toggleId" 
-            (focus)="onFocus()" 
-            type="text" 
-            class="dlt-date-picker" 
-            [placeholder]="transform.dateInputFields[0].format" 
-            [ngModel]="field.content.trim()" 
-            [ngStyle]="{'grid-row-start': field.position.row, 'grid-column-start': field.position.column}">
+    <input
+      (focus)="onFocus()" 
+      type="text" 
+      class="dlt-date-picker" 
+      [placeholder]="transform.dateInputFields[0].format"
+      value="{{field.content.trim()}}"             
+      [ngStyle]="{'grid-row-start': field.position.row, 'grid-column-start': field.position.column}">
     <i #datepickerIcon class="dlt-icon-calendar datepicker-icon"></i>
   </div>
 </div>

--- a/src/app/mini-components/transformations/calendar/calendar.component.ts
+++ b/src/app/mini-components/transformations/calendar/calendar.component.ts
@@ -16,7 +16,6 @@
 import {AfterViewInit, Component, ElementRef, Input, OnChanges, OnInit, SimpleChanges, ViewChild} from '@angular/core';
 import {CalendarTransformation, Cursor, Field, InputField } from '@softwareag/applinx-rest-apis';
 import {NavigationService} from '../../../services/navigation/navigation.service';
-import {GXUtils} from 'src/utils/GXUtils'
 declare var $: any;
 
 @Component({
@@ -35,14 +34,14 @@ export class CalendarComponent implements OnInit, OnChanges, AfterViewInit {
   constructor(private navigationService: NavigationService) { }
 
   ngAfterViewInit(): void {
-    const myDatePicker = $(`[data-toggle="${this.toggleId}"]`).datepicker({
+    $(".dlt-date-picker").datepicker({
       // Hide the datepicker automatically when picked
       autoHide: true,
       trigger: this.datepickerIcon.nativeElement,
       format: this.transform.dateInputFields[0].format,
     });
 
-    myDatePicker.on('change', (e) => {
+    $(".dlt-date-picker").on('change', (e) => {
       this.sendableField.setValue(e.target.value);
       this.navigationService.setSendableField(this.sendableField);
     });
@@ -56,13 +55,11 @@ export class CalendarComponent implements OnInit, OnChanges, AfterViewInit {
 
   ngOnChanges(changes: SimpleChanges): void {
     this.field = changes.transform.currentValue.dateInputFields[0].field;
-
     this.sendableField = new InputField();
     this.sendableField.setValue(this.field.content);
     this.sendableField.setPosition(this.field.position);
     this.sendableField.setIndex(this.field.index);
     this.sendableField.setName(this.field.name);
-    this.toggleId = 'datepicker' + GXUtils.posToString(this.field.position);
   }
 
   onFocus(): void {


### PR DESCRIPTION
when clicking the datepicker field, the date table opened with the current month instead of the initial value of the input field.